### PR TITLE
`passportStub.uninstall()` に不要な `app` 引数を削除

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ describe('/login', () => {
 
   afterAll(() => {
     passportStub.logout();
-    passportStub.uninstall(app);
+    passportStub.uninstall();
   });
 
   test('ログインのためのリンクが含まれる', async () => {
@@ -51,7 +51,7 @@ describe('/schedules', () => {
 
   afterAll(async () => {
     passportStub.logout();
-    passportStub.uninstall(app);
+    passportStub.uninstall();
 
     // テストで作成したデータを削除
     const candidates = await Candidate.findAll({


### PR DESCRIPTION
`passportStub.uninstall()` に不要な `app` 引数を削除しました
（ https://github.com/nnn-training/change-repo-contents-all を使って作成しました）